### PR TITLE
Added absolute path fix for Makefile.deps

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -1,8 +1,8 @@
-CURRENT_DIR=$(dir $(abspath $(lastword $(MAKEFILE_LIST))))
- 
-include $(CURRENT_DIR)/Makefile.deps
+BLADERUNNER_ROOT=$(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
-BUILD_PATH := $(shell pwd)
+include $(BLADERUNNER_ROOT)/Makefile.deps
+
+BUILD_PATH := $(BLADERUNNER_ROOT)
 
 define upper
 $(shell echo $(1) | tr [:lower:] [:upper:])


### PR DESCRIPTION
This allows BSG_F1 to include Makefile.common to set BSG_IP_CORES_DIR and BSG_MANYCORE_DIR and allow cosimulation from inside bladerunner.