### PR TITLE
fixes the two slash issue in path variables

### DIFF
--- a/project.mk
+++ b/project.mk
@@ -27,7 +27,7 @@
 
 DEPENDENCIES           := bsg_manycore bsg_f1 basejump_stl
 
-BLADERUNNER_ROOT       := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+BLADERUNNER_ROOT       := $(abspath $(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
 BUILD_PATH             := $(BLADERUNNER_ROOT)
 
 BSG_F1_DIR             := $(BLADERUNNER_ROOT)/bsg_f1


### PR DESCRIPTION
* fixes an issue where the path variables to project directories have `//`
* this causes a problem when using a C macro to stringify a file path as `//` tokenizes to a comment