### PR TITLE
Default macOS Verilator models to one worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,16 +137,16 @@ gmake -f amibuild.mk riscv-gcc
 The broader `riscv-tools` target also builds Spike and the customized LLVM tree;
 those components are not required for the Verilator warmup.
 
-For a conservative first application run, build the execution model with one
-Verilator worker thread:
+On macOS, the execution model defaults to one Verilator worker thread:
 
 ```sh
-gmake VERILATOR_THREADS=1 exec.log
+gmake exec.log
 ```
 
-The default is 16 threads. The setting is fixed when a machine model is
-generated, so run `gmake platform.link.clean` before rebuilding that machine
-with a different thread count.
+Other hosts continue to default to 16 workers. Override the count explicitly,
+for example with `gmake VERILATOR_THREADS=4 exec.log`, after benchmarking the
+specific model. The selected count is stored with the generated execution
+model, and changing it automatically invalidates and rebuilds that model.
 
 
 ## Examples


### PR DESCRIPTION
## Summary

- update bsg_replicant to merged upstream commit 7c2fb506 from bespoke-silicon-group/bsg_replicant#871
- document the one-worker Darwin default
- document explicit overrides and automatic generated-model invalidation

## Motivation

On the validated Apple Silicon 4x2 model, one Verilator worker is substantially faster than 16:

- memcpy: 1.04 s versus 4.10 s
- SGEMM N=64, NITER=1: 1.73 s versus 7.11 s

The Replicant fix retains the 16-worker default on non-Darwin hosts while preventing a model generated with one worker count from being silently reused for another.

## Validation

- Replicant PR #871 is merged
- generated execution model reports one worker with the Darwin default
- memcpy and SGEMM correctness runs pass
- unchanged worker count is a no-op rebuild
- the simulator retains its 32 MiB Darwin main-thread stack